### PR TITLE
Declare BSF_KEEP_G in support/bfdgen.c

### DIFF
--- a/support/bfdgen.c
+++ b/support/bfdgen.c
@@ -54,6 +54,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 # define BSF_SYNTHETIC 0
 #endif
 
+#ifndef BSF_KEEP_G
+# define BSF_KEEP_G 0
+#endif
+
 #ifndef BSF_GNU_INDIRECT_FUNCTION
 # define BSF_GNU_INDIRECT_FUNCTION 0
 #endif


### PR DESCRIPTION
Binutils commit b8871f3 renamed BSF_KEEP_G to BSF_ELF_COMMON. Add define
for BSF_KEEP_G to support/bfdgen.c if it is undefined to allow
compilation of ada-bfd with newer binutils versions (i.e. the one
provided in Debian Stretch).