### PR TITLE
Util.Strings: Add missing with Ada.Finalization

### DIFF
--- a/testutil/util-strings.ads
+++ b/testutil/util-strings.ads
@@ -20,6 +20,7 @@ with Ada.Strings.Unbounded;
 with Ada.Containers;
 with Ada.Containers.Hashed_Maps;
 with Ada.Containers.Hashed_Sets;
+with Ada.Finalization;
 with Util.Concurrent.Counters;
 package Util.Strings is
 


### PR DESCRIPTION
GNAT Pro 25.2 correctly complains:

util-strings.ads:116:31: error: missing "with Ada.Finalization;"
util-strings.ads:120:04: error: pragma "Finalize_Storage_Only" must specify controlled type
util-strings.ads:124:04: error: subprogram "Adjust" is not overriding
util-strings.ads:128:04: error: subprogram "Finalize" is not overriding
util-strings.ads:116:31: error: missing "with Ada.Finalization;"
util-strings.ads:120:04: error: pragma "Finalize_Storage_Only" must specify controlled type
util-strings.ads:124:04: error: subprogram "Adjust" is not overriding
util-strings.ads:128:04: error: subprogram "Finalize" is not overriding